### PR TITLE
Force notification use JSON stringify and reject can add reason

### DIFF
--- a/frontend/src/components/HHeader.vue
+++ b/frontend/src/components/HHeader.vue
@@ -15,7 +15,7 @@
       </a-menu-item>
       <a-sub-menu :style="{ float: 'right' }">
         <span slot="title">
-            <span>{{ user.display_name }}</span>
+            <span :style="{margin: '10px'}">{{ user.display_name }}</span>
             <a-avatar shape="square" icon="user"
                       :src="user.avatar"
             />

--- a/frontend/src/utils/HRequests.js
+++ b/frontend/src/utils/HRequests.js
@@ -20,16 +20,18 @@ HRequest.interceptors.response.use((response) => {
     }
   } else if (error.response.status === 403) {
     // 403, insufficient privillege, Redirect to login page
-    vm.$message.warning('Insufficient privilege!' + error.response.status + ':' + error.response.data)
+    vm.$message.warning('Insufficient privilege!' + error.response.status + ':' + JSON.stringify(error.response.data))
     if (vm.$route.name !== 'Login') {
       vm.$router.push({name: 'Login', query: {next: currentPath}})
     }
   } else if (error.response.status >= 500) {
-    vm.$message.error('Internal error, please contact webadmin' + error.response.status + ':' + error.response.data)
+    vm.$message.error('Internal error, please contact webadmin' + error.response.status + ':' + JSON.stringify(error.response.data))
   } else {
     // > 500 internal error, notify only
     // > 404 notify only
-    vm.$message.warning('Request failed: ' + error.response.status + ':' + error.response.data)
+    const rawMsg = JSON.stringify(error.response.data)
+    const msg = rawMsg.length > 150 ? rawMsg.slice(0, 150) + '...' : rawMsg
+    vm.$message.warning('Request failed: ' + error.response.status + ':' + msg)
   }
   return Promise.reject(error)
 })


### PR DESCRIPTION
- notification use stringify force to string rather than showing `[object][object]`
- mark api setting ticket status is final status and will not be changed by `show result` button even they are different
- reject now can send a reason for user, the ticket `reason` field will show the reject reason rather than apply reason
- `details` link in ticket list link to `/tickt/xx` for better experience 

will resolve #26 