### PR TITLE
delete taggable for select & make form submittable after validate failure

### DIFF
--- a/frontend/src/components/FormWidgets/SelectInput.vue
+++ b/frontend/src/components/FormWidgets/SelectInput.vue
@@ -12,7 +12,6 @@
       :clearable="true"
       :searchable="true"
       :filterable="true"
-      :taggable="true"
       :select-on-tab="true"
       @input="handleInput"
       @keypress.enter.native.prevent=""

--- a/frontend/src/components/HForm.vue
+++ b/frontend/src/components/HForm.vue
@@ -140,6 +140,9 @@ export default {
           }).finally(() => {
             this.canSubmit = true
           })
+        } else {
+          // validate failed, make the form submittable again
+          this.canSubmit = true
         }
       })
     },


### PR DESCRIPTION
taggable 使用户可以自己输入自定义的选项, 不需要这个选项

表单提交时提交按钮会暂时禁用, 在表单验证失败的场合, 提交按钮不会重新启用, 造成无法继续提交表单的问题.