### PR TITLE
Add json schema form verify && add dag for airflow && fix bugs

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2352,10 +2352,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
-      "dev": true,
+      "version": "6.12.4",
+      "resolved": "https://registry.npm.taobao.org/ajv/download/ajv-6.12.4.tgz?cache=0&sync_timestamp=1597480799381&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fajv%2Fdownload%2Fajv-6.12.4.tgz",
+      "integrity": "sha1-BhT6zEUiEn+nE0Rca/0+vTduIjQ=",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3997,6 +3996,14 @@
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
+    "clone-regexp": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npm.taobao.org/clone-regexp/download/clone-regexp-2.2.0.tgz",
+      "integrity": "sha1-fWXgCIXNh5ZAXDWnN+eoa3Qp428=",
+      "requires": {
+        "is-regexp": "^2.0.0"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5113,6 +5120,11 @@
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
       "dev": true
     },
+    "diacritics": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npm.taobao.org/diacritics/download/diacritics-1.3.0.tgz",
+      "integrity": "sha1-PvqHMj67hj5mls67AILUj/PW96E="
+    },
     "diff-sequences": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
@@ -6085,9 +6097,8 @@
     },
     "fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "resolved": "https://registry.npm.taobao.org/fast-deep-equal/download/fast-deep-equal-3.1.3.tgz?cache=0&sync_timestamp=1591599651635&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffast-deep-equal%2Fdownload%2Ffast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
     },
     "fast-glob": {
       "version": "2.2.7",
@@ -6129,8 +6140,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -6544,6 +6554,11 @@
         "pify": "^4.0.1",
         "slash": "^2.0.0"
       }
+    },
+    "gojs": {
+      "version": "2.1.23",
+      "resolved": "https://registry.npm.taobao.org/gojs/download/gojs-2.1.23.tgz",
+      "integrity": "sha1-XlAcarK1oZcgJVn03xlZp9R/aJA="
     },
     "graceful-fs": {
       "version": "4.2.4",
@@ -7526,6 +7541,11 @@
       "requires": {
         "has-symbols": "^1.0.1"
       }
+    },
+    "is-regexp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npm.taobao.org/is-regexp/download/is-regexp-2.1.0.tgz",
+      "integrity": "sha1-zXNKVoZOI7lWv058ZsOWpMCyLC0="
     },
     "is-resolvable": {
       "version": "1.1.0",
@@ -8805,9 +8825,8 @@
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "resolved": "https://registry.npm.taobao.org/json-schema-traverse/download/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -11215,8 +11234,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -13404,10 +13422,9 @@
       "dev": true
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
+      "version": "4.4.0",
+      "resolved": "https://registry.npm.taobao.org/uri-js/download/uri-js-4.4.0.tgz?cache=0&sync_timestamp=1598814377097&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Furi-js%2Fdownload%2Furi-js-4.4.0.tgz",
+      "integrity": "sha1-qnFCYd55PoqCNHp7zJznTobyhgI=",
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -13691,6 +13708,15 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vue-text-highlight": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npm.taobao.org/vue-text-highlight/download/vue-text-highlight-2.0.10.tgz",
+      "integrity": "sha1-fBo+r5uRWTCpOe7t+O5iV1Cf7mc=",
+      "requires": {
+        "clone-regexp": "^2.1.0",
+        "diacritics": "^1.3.0"
+      }
     },
     "vuex": {
       "version": "3.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,13 +9,16 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "ajv": "^6.12.4",
     "ant-design-vue": "^1.2.4",
     "axios": "^0.19.0",
     "core-js": "^3.6.5",
+    "gojs": "^2.1.23",
     "qs": "^6.9.4",
     "vue": "^2.6.11",
     "vue-router": "^3.1.5",
     "vue-select": "^3.1.0",
+    "vue-text-highlight": "^2.0.10",
     "vuex": "^3.1.2"
   },
   "devDependencies": {

--- a/frontend/src/components/HTicketDetail.vue
+++ b/frontend/src/components/HTicketDetail.vue
@@ -182,7 +182,7 @@ export default {
     loadTickets () {
       HRequest.get('/api/ticket/' + this.$route.params.id).then(
         (response) => {
-          this.handleTicketList(response)
+          this.table_data = response.data.data.tickets
           switch (this.$route.params.action) {
             case 'approve':
               this.onApprove()
@@ -195,11 +195,13 @@ export default {
             default:
               this.$message.warning('Action ' + this.$route.params.action + 'for this ticket is invalid.')
           }
-        }
-      )
+        })
     },
-    handleTicketList (response) {
-      this.table_data = response.data.data.tickets
+    updateTicket () {
+      HRequest.get('/api/ticket/' + this.$route.params.id).then(
+        (response) => {
+          this.table_data = response.data.data.tickets
+        })
     },
     UTCtoLcocalTime,
     toggleResult () {
@@ -236,6 +238,7 @@ export default {
         return
       }
       HRequest.post(this.ticketInfo.reject_url, {"reason": this.rejectReason}).then(() => {
+        this.updateTicket()
         this.$message.info('Ticket rejected.')
         this.$router.push({ name: 'HTicketDetail', params: { id: this.$route.params.id }})
         this.hideRejectModal()
@@ -253,6 +256,7 @@ export default {
         return
       }
       HRequest.post(this.ticketInfo.approve_url).then(() => {
+        this.updateTicket()
         this.$message.info('Ticket approved.')
         this.$router.push({ name: 'HTicketDetail', params: { id: this.$route.params.id }})
       }).catch((error) => {

--- a/frontend/src/components/Hdag.vue
+++ b/frontend/src/components/Hdag.vue
@@ -1,0 +1,88 @@
+<template>
+    <div style="border: solid 1px white; width:100%; height:400px">
+    </div>
+</template>
+
+<script>
+import go from 'gojs'
+
+export default {
+    name: "Hdag",
+    props: ["modelData", "selectedNode"],  // accept model data as a parameter
+    mounted: function() {
+        var $ = go.GraphObject.make;
+        var self = this;
+        var myDiagram =
+        $(go.Diagram, this.$el,
+            {
+            initialContentAlignment: go.Spot.Center,
+            layout: $(go.TreeLayout, { angle: 90, arrangement: go.TreeLayout.ArrangementVertical }),
+            "undoManager.isEnabled": false,
+            isReadOnly: true,
+            // Model ChangedEvents get passed up to component users
+            "ModelChanged": function(e) { self.$emit("model-changed", e); },
+            "ChangedSelection": function(e) { self.$emit("changed-selection", e); }
+            });
+
+        myDiagram.nodeTemplate =
+        $(go.Node, "Auto",
+            $(go.Shape,
+            {
+                fill: "white", strokeWidth: 2,
+                stroke: "#6699ff",
+                portId: "", fromLinkable: true, toLinkable: true, cursor: "pointer"
+            },
+            new go.Binding("fill", "color"), new go.Binding("stroke", "stroke")),
+            $(go.TextBlock,
+            { margin: 8, editable: true },
+            new go.Binding("text").makeTwoWay())
+        );
+
+        myDiagram.linkTemplate =
+        $(go.Link,
+            { relinkableFrom: true, relinkableTo: true },
+            $(go.Shape),
+            $(go.Shape, { toArrow: "OpenTriangle" })
+        );
+
+        this.diagram = myDiagram;
+        this.updateModel(this.modelData);
+    },
+    watch: {
+        modelData: function(val) { this.updateModel(val); },
+        selectedNode: function(newV, oldV) {
+            console.log('old v: ' + oldV)
+            var node = this.diagram.findNodeForKey(newV)
+            this.diagram.select(node)
+
+        },
+    },
+    methods: {
+        model: function() { return this.diagram.model; },
+        updateModel: function(val) {
+        // No GoJS transaction permitted when replacing Diagram.model.
+        if (val instanceof go.Model) {
+            this.diagram.model = val;
+        } else {
+            var m = new go.GraphLinksModel()
+            if (val) {
+            for (var p in val) {
+                m[p] = val[p];
+            }
+            }
+            this.diagram.model = m;
+        }
+        },
+        updateDiagramFromData: function() {
+            this.diagram.startTransaction();
+            // This is very general but very inefficient.
+            // It would be better to modify the diagramData data by calling
+            // Model.setDataProperty or Model.addNodeData, et al.
+            this.diagram.updateAllRelationshipsFromData();
+            this.diagram.updateAllTargetBindings();
+            this.diagram.initialContentAlignment = go.Spot.Center;
+            this.diagram.commitTransaction("updated");
+        }
+      }
+}
+</script>

--- a/frontend/src/components/Hdag.vue
+++ b/frontend/src/components/Hdag.vue
@@ -50,8 +50,7 @@ export default {
     },
     watch: {
         modelData: function(val) { this.updateModel(val); },
-        selectedNode: function(newV, oldV) {
-            console.log('old v: ' + oldV)
+        selectedNode: function(newV) {
             var node = this.diagram.findNodeForKey(newV)
             this.diagram.select(node)
 

--- a/frontend/src/components/ResultHostTable.vue
+++ b/frontend/src/components/ResultHostTable.vue
@@ -40,7 +40,11 @@
           </span>
           <span>
             <h3>stderr: </h3>
-            <pre class="text-wrapper">{{typeof(record.stderr) === 'string' ? record.stderr : ''}}</pre>
+            <pre class="text-wrapper">
+              <text-highlight :queries='highlightQueries' :highlightStyle='highlightStyle'>
+                {{typeof(record.stderr) === 'string' ? record.stderr : ''}}
+              </text-highlight>
+            </pre>
           </span>
           <span>
             <h3>stdout: </h3>
@@ -57,14 +61,18 @@
 </template>
 
 <script>
+import TextHighlight from 'vue-text-highlight';
 import {HRequest} from '../utils/HRequests'
 
 export default {
   name: 'ResultHostTable',
+  components: {TextHighlight},
   props: ['resultData', 'dataLoaded', 'ticketId'],
   data () {
     return {
       spinning: false,
+      highlightQueries: [],
+      highlightStyle: {color: 'green', 'background': 'yellow'},
       results: [{}],
       filtered: {},
       successCount: 0,
@@ -125,6 +133,7 @@ export default {
       let count = 0
       let successCount = 0
       let failedCount = 0
+      this.highlightQueries = []
       for (let property in data) {
         let el = data[property]
         count += 1
@@ -142,6 +151,15 @@ export default {
           el.status = 'Failed'
         }
         listData.push(el)
+        
+        if (el.highlight_queries) {
+          for (let r of el.highlight_queries) {
+            var re = new RegExp(r)
+            if (this.highlightQueries.indexOf(re) === -1) {
+              this.highlightQueries.push(re)
+            }
+          } 
+        }
       }
       this.successCount = successCount
       this.failedCount = failedCount

--- a/frontend/src/components/SubTabNoRecursive.vue
+++ b/frontend/src/components/SubTabNoRecursive.vue
@@ -5,7 +5,7 @@
         {{ value.name.length > 30 ? value.name.slice(0, 30) + '...': value.name }}
       </template>
       <result-host-table v-bind:data-loaded="dataLoaded" v-bind:resultData="value.result" 
-      :ticketId="ticketId" v-bind:highlightQueries="resultData.highlight_queries"></result-host-table>
+      :ticketId="ticketId"></result-host-table>
     </a-tab-pane>
   </a-tabs>
 </template>
@@ -13,7 +13,7 @@
 import ResultHostTable from './ResultHostTable'
 export default {
   components: {ResultHostTable},
-  props: ['resultData', 'dataLoaded', 'ticketId', 'ticketProvider', 'resultActiveKey', 'highlightQueries'],
+  props: ['resultData', 'dataLoaded', 'ticketId', 'ticketProvider', 'resultActiveKey'],
   methods: {
       tabClickHandler (key) {
           this.$emit('tabClicked', key)

--- a/frontend/src/components/SubTabNoRecursive.vue
+++ b/frontend/src/components/SubTabNoRecursive.vue
@@ -1,0 +1,23 @@
+<template>
+  <a-tabs type="card" :tabPosition="'left'" :activeKey="resultActiveKey" @tabClick='tabClickHandler'>
+    <a-tab-pane v-for="value of resultData.tasks" :key="value.id">
+      <template slot="tab">
+        {{ value.name.length > 30 ? value.name.slice(0, 30) + '...': value.name }}
+      </template>
+      <result-host-table v-bind:data-loaded="dataLoaded" v-bind:resultData="value.result" 
+      :ticketId="ticketId" v-bind:highlightQueries="resultData.highlight_queries"></result-host-table>
+    </a-tab-pane>
+  </a-tabs>
+</template>
+<script>
+import ResultHostTable from './ResultHostTable'
+export default {
+  components: {ResultHostTable},
+  props: ['resultData', 'dataLoaded', 'ticketId', 'ticketProvider', 'resultActiveKey', 'highlightQueries'],
+  methods: {
+      tabClickHandler (key) {
+          this.$emit('tabClicked', key)
+      }
+  }
+}
+</script>

--- a/helpdesk/libs/airflow.py
+++ b/helpdesk/libs/airflow.py
@@ -209,6 +209,26 @@ class AirflowClient:
             all_task_result[task_id] = {'message': [str(e)], 'metadata': {'end_of_log': True}, 'success': 1}
         return {'dag_id': dag_id, 'execution_date': execution_date, 'task_id': task_id, 'result': all_task_result}
 
+    @auto_refresh_token
+    def get_dag_graph(self, dag_id):
+        api_headers = {
+            'Authorization': 'Bearer {}'.format(self._access_token),
+            'Cache-Control': 'no-cache',
+            'Content-Type': 'application/json'
+        }
+
+        task_result = requests.get(
+            url=f'{self.server_url}/admin/helpdesk/api/dags/{dag_id}/graph',
+            headers=api_headers
+        )
+        try:
+            result = self._check_resp(
+                task_result, AirflowClientTaskResultException, 'Get dag graph error: {}'.format(dag_id))
+            return result
+        except AirflowClientTaskResultException as e:
+            logger.error(f'Get {dag_id} graph error: {str(e)}')
+            return {}
+
     @timed_cache(minutes=15)
     @auto_refresh_token
     def get_user_roles(self, username):

--- a/helpdesk/libs/spincycle.py
+++ b/helpdesk/libs/spincycle.py
@@ -71,7 +71,7 @@ class SpinCycleClient:
                 "args": args
             }),
             headers={'Content-Type': 'application/json'},
-            verify=self.verify)
+    )
         return self._check_resp(result, SpinClientCreateReqException, msg='create and start request error: {}')
 
     @staticmethod
@@ -84,15 +84,15 @@ class SpinCycleClient:
             raise exception(msg.format(resp.text))
 
     def get_req(self, req_id):
-        result = requests.get(url=f"{self.api_prefix}/requests/{req_id}", auth=self._auth, verify=self.verify)
+        result = requests.get(url=f"{self.api_prefix}/requests/{req_id}", auth=self._auth)
         return self._check_resp(result, SpinClientGetReqException)
 
     def stop_req(self, req_id):
-        result = requests.put(url=f"{self.api_prefix}/requests/{req_id}/stop", auth=self._auth, verify=self.verify)
+        result = requests.put(url=f"{self.api_prefix}/requests/{req_id}/stop", auth=self._auth)
         return self._check_resp(result, SpinClientException)
 
     def get_all_job_logs_by_req(self, req_id):
-        result = requests.get(url=f"{self.api_prefix}/requests/{req_id}/log", auth=self._auth, verify=self.verify)
+        result = requests.get(url=f"{self.api_prefix}/requests/{req_id}/log", auth=self._auth)
         return self._check_resp(result, SpinClientGetJobLogsException)
 
     def get_req_result_url(self, req_id):
@@ -100,21 +100,21 @@ class SpinCycleClient:
 
     def get_job_log_by_req(self, req_id, job_id):
         result = requests.get(
-            url=f"{self.api_prefix}/requests/{req_id}/log/{job_id}", auth=self._auth, verify=self.verify)
+            url=f"{self.api_prefix}/requests/{req_id}/log/{job_id}", auth=self._auth)
         return self._check_resp(result, SpinClientGetJobLogFromReqException)
 
     def get_running_jobs_and_req(self):
-        result = requests.get(url=f"{self.api_prefix}/status/running", auth=self._auth, verify=self.verify)
+        result = requests.get(url=f"{self.api_prefix}/status/running", auth=self._auth)
         return self._check_resp(result, SpinClientGetRunningException)
 
     def get_req_by_filter(self, filter_dict):
         result = requests.get(
-            url=f"{self.api_prefix}/requests", params=filter_dict, auth=self._auth, verify=self.verify)
+            url=f"{self.api_prefix}/requests", params=filter_dict, auth=self._auth)
         return self._check_resp(result, SpinClientFindReqException)
 
     @timed_cache(minutes=10)
     def get_req_list(self):
-        result = requests.get(url=f"{self.api_prefix}/request-list", auth=self._auth, verify=self.verify)
+        result = requests.get(url=f"{self.api_prefix}/request-list", auth=self._auth)
         return self._check_resp(result, SpinClientGetReqListException)
 
     def get_req_by_type(self, type):
@@ -126,7 +126,7 @@ class SpinCycleClient:
             raise SpinClientFindReqException("can not find req by type: {}".format(type))
 
     def get_job_chain_by_req_id(self, req_id):
-        result = requests.get(url=f"{self.api_prefix}/requests/{req_id}/job-chain", auth=self._auth, verify=self.verify)
+        result = requests.get(url=f"{self.api_prefix}/requests/{req_id}/job-chain", auth=self._auth)
         return self._check_resp(result, SpinClientException)
 
     def get_ascii_graph_of_req(self, req_id, state_number_to_note=None):

--- a/helpdesk/models/action.py
+++ b/helpdesk/models/action.py
@@ -32,6 +32,9 @@ class Action(DictSerializableClassMixin):
     def description(self, provider):
         return self.get_action(provider).get('description')
 
+    def params_json_schema(self, provider):
+        return self.get_action(provider).get('params_json_schema')
+
     def parameters(self, provider, user):
         parameters = self.get_action(provider).get('parameters', {})
         for k, v in parameters.items():
@@ -48,6 +51,8 @@ class Action(DictSerializableClassMixin):
         action_d = super(Action, self).to_dict(**kw)
         if provider and user:
             action_d['params'] = self.parameters(provider, user)
+            action = self.get_action(provider)
+            action_d['params_json_schema'] = action.get('params_json_schema')
         return action_d
 
     async def run(self, provider, form, user):

--- a/helpdesk/views/api/index.py
+++ b/helpdesk/views/api/index.py
@@ -187,7 +187,7 @@ async def mark_ticket(request):
         data = await request.json()
         assert 'execution_status' in data, "mark body fields error"
         ticket.annotate(execution_status=data["execution_status"], final_exec_status=True)
-        logger.debug(f"tocket annotaion: {ticket.annotation}")
+        logger.debug(f"ticket annotation: {ticket.annotation}")
         # add notification to ticket mark action
         await ticket.notify(TicketPhase.MARK)
         await ticket.save()


### PR DESCRIPTION
1. Add json schema validate for airflow provider

在dag的定义里增加一个params_json_schema的可选字段即可，ref: https://json-schema.org/

示例表示需要 f/c 字段，d/b/g 有且只能有一个,e是逗号分割的array字符串，每个字符串需要满足uri的标准格式，c必须满足pattern正则且最小长度为3等等约束.

因为dynamic-form的局限，对string之类的类型支持是前端转换之后做了校验，接收到的表单数据还是原来的表单数据（string only)

```python
'params_json_schema': {
            "type": "object",
            "properties": {
                "a": {"type": "integer", "minimum": 3, "maximum": 30},
                "b": {"type": "string"},
                "c": {"type": "string", "pattern": "^'.+'$", "minLength": 3},
                "d": {"type": "string"},
                "e": {"type": "array", "items": {"type": "string", "format": "uri"},
                         "uniqueItems": True, "minItems": 1},
                "f": {"type": "string"},
                "g": {"type": "string"},
            },
            "oneOf": [
                {"required": ["d"]},
                {"required": ["b"]},
                {"required": ["g"]}
            ],
            "required": ["f", "c"]
        },
```

2. airflow的provider可以显示dag图和状态并点击切换查看日志了

![image](https://user-images.githubusercontent.com/3339663/92469032-b47c6c00-f206-11ea-8eba-073b386f8728.png)

3. 给airflow的日志加了一个highlight的功能，后端可以指定一个`highlight_queries` 的list来表示需要高亮的字段，查找日志更简单点。

![image](https://user-images.githubusercontent.com/3339663/92469400-54d29080-f207-11ea-9dde-9e644cac6e28.png)

4. 修复了一些小问题，比如spincycle的verify/fix typo
