### PR TITLE
fix aiomysql & PyMySQL conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,6 @@ prettytable==1.0.1
 prompt-toolkit==1.0.15
 psycopg2==2.8.6
 pycparser==2.20
-PyMySQL==0.10.1
 pyOpenSSL==19.1.0
 python-dateutil==2.8.0
 python-dotenv==0.15.0


### PR DESCRIPTION
```
+ pip install --no-cache-dir -r requirements.txt
Collecting aiofiles==0.6.0
  Downloading aiofiles-0.6.0-py3-none-any.whl (11 kB)
Collecting aiomysql==0.0.20
  Downloading aiomysql-0.0.20-py3-none-any.whl (40 kB)
INFO: pip is looking at multiple versions of aiofiles to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r requirements.txt (line 2) and PyMySQL==0.10.1 because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies

The conflict is caused by:
    The user requested PyMySQL==0.10.1
    aiomysql 0.0.20 depends on PyMySQL<=0.9.2 and >=0.9
```