### PR TITLE
delete some pined versions to fix pip issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,13 +37,11 @@ python-dotenv==0.15.0
 python-editor==1.0.4
 python-multipart==0.0.5
 pytz==2019.1
-PyYAML==5.3.1
 requests==2.23.0
 rfc3986==1.4.0
 rule==0.1.1
 sentry-asgi==0.2.0
 sentry-sdk==0.19.1
-six==1.15.0
 sniffio==1.2.0
 SQLAlchemy==1.3.20
 SQLAlchemy-Utils==0.36.8


### PR DESCRIPTION
pip 在升级到 20.3 后依赖控制有些 breaking change, 现在删除掉这些pin得基础包, 修复版本冲突