### PR TITLE
Add rerun to ticket action

### DIFF
--- a/frontend/src/components/DynamicForm.vue
+++ b/frontend/src/components/DynamicForm.vue
@@ -22,13 +22,16 @@ export default {
   components: {AFormItem, NumberInput, TextInput, SelectInput, CheckBoxInput},
   props: ['schema', 'value'],
   data () {
-    return {
-      formData: this.value || {}
+    return {}
+  },
+  computed: {
+    formData: function () {
+      return this.value || {}
     }
   },
   methods: {
-    updateForm (fieldName, value) {
-      this.$set(this.formData, fieldName, value)
+    updateForm (fieldName, v) {
+      this.$set(this.formData, fieldName, v)
       this.$emit('input', this.formData)
     }
   }

--- a/frontend/src/components/FormWidgets/SelectInput.vue
+++ b/frontend/src/components/FormWidgets/SelectInput.vue
@@ -34,6 +34,13 @@ export default {
       selectedValues: []
     }
   },
+  watch: {
+    value: function () {
+      if (this.selectedValues.join(',') != this.value) {
+        this.selectedValues = this.value.split(',')
+      }
+    }
+  },
   methods: {
     handleInput (event) {
       let realValue = event.join()

--- a/frontend/src/components/HForm.vue
+++ b/frontend/src/components/HForm.vue
@@ -135,11 +135,21 @@ export default {
 
       const queryParams = this.$route.query
       if (queryParams.backfill && Number(queryParams.backfill) > 0) {
+        const notificationTitle = "Rerun ticket " + queryParams.backfill + " error"
         HRequest.get('/api/ticket/' + queryParams.backfill).then(
           (response) => {
             const ticketsLen = response.data.data.tickets.length
             if (ticketsLen == 1) {
-              this.handleInput(response.data.data.tickets[0].params)
+              const isTheSameAction = this.$route.path.endsWith(response.data.data.tickets[0].provider_object)
+              const ticket = response.data.data.tickets[0]
+              if (isTheSameAction) {
+                this.handleInput(ticket.params)
+              } else {
+                this.errorAsNotification(
+                  notificationTitle,
+                  "The backfill ticket should be the same action ticket, but ticket " + queryParams.backfill + "'s action was: " + ticket.provider_object
+                )
+              }
             } else {
               this.errorAsNotification(
                 "Rerun ticket " + queryParams.backfill + " error",
@@ -149,7 +159,7 @@ export default {
           }
         ).catch((error) => {
           this.errorAsNotification(
-            "Rerun ticket " + queryParams.backfill + " error",
+            notificationTitle,
             error.response.data.data.description
           )
         })

--- a/frontend/src/components/HTicketDetail.vue
+++ b/frontend/src/components/HTicketDetail.vue
@@ -86,6 +86,7 @@
           <a-button @click="onApprove" type="primary">Approve</a-button>
         </a-button-group>
         <a-button v-show="showResultButton" :style="{ marginLeft: '16px' }" @click="toggleResult">{{resultButtonText}}</a-button>
+        <a-button v-show="showResultButton" :style="{ marginLeft: '5px' }" @click="rerunTicket">Rerun</a-button>
         <a-button v-show="resultVisible" :style="{ marginLeft: '5px' }" @click="loadTResult">Refresh</a-button>
         
         <a-switch v-show="resultVisible" :style="{ marginLeft: '5px' }" 
@@ -287,6 +288,9 @@ export default {
     loadTResult (e, callback) {
       this.loadTickets()
       this.$refs.ticketResult.loadResult(callback)
+    },
+    rerunTicket () {
+      this.$router.push({ name: 'FormView', params: { name: this.ticketInfo.provider_object }, query: { backfill: this.ticketInfo.id }})
     },
     isTicketEndStatus() {
       const ticketStatus = this.ticketInfo.status

--- a/frontend/src/components/HTicketList.vue
+++ b/frontend/src/components/HTicketList.vue
@@ -53,7 +53,7 @@
 
         <a :href="record.url">detail</a>
         <a-divider type="vertical" />
-        <a :href="'/' + record.provider_object + '?backfill=' + record.id"> rerun</a>
+        <router-link :to="{ name: 'FormView', params: { name: record.provider_object }, query: { backfill: record.id }}">rerun</router-link>
         </span>
     </a-table>
     <a-modal

--- a/frontend/src/components/HTicketList.vue
+++ b/frontend/src/components/HTicketList.vue
@@ -52,6 +52,8 @@
         </span>
 
         <a :href="record.url">detail</a>
+        <a-divider type="vertical" />
+        <a :href="'/' + record.provider_object + '?backfill=' + record.id"> rerun</a>
         </span>
     </a-table>
     <a-modal


### PR DESCRIPTION
Fix #25 

Add a rerun link at ticket list. It will backfill params to the action form with this ticket's info. User can either edit value or just submit again.

![image](https://user-images.githubusercontent.com/3339663/102443626-2a903a80-4062-11eb-8e7e-1242af9d8bab.png)
