### PR TITLE
Isolate provider init

### DIFF
--- a/frontend/src/components/HSider.vue
+++ b/frontend/src/components/HSider.vue
@@ -44,7 +44,8 @@ export default {
       openKeys: [],
       SelectedKeys: [],
       rootSubmenuKeys: [],
-      searchText: ''
+      searchText: '',
+      actionLoadNotifyKey: 'actionTreeLoadErrorNofify'
     }
   },
   computed: {
@@ -69,6 +70,7 @@ export default {
           for (let i = 0; i < definition.length; i++) {
             this.rootSubmenuKeys.push(definition[i].key)
           }
+          this.checkActionTreeError(definition)
           this.$store.dispatch('updateActionTree', definition)
           let actionName = this.$route.params.name
           // looking for selected item with actionName
@@ -83,6 +85,25 @@ export default {
           }
         }
       )
+    },
+    checkActionTreeError(definition) {
+      // check action 
+      var loadErrorAction = []  
+      for (let i = 0; i < definition.length; i++) {
+        if (definition[i].children && definition[i].children.length == 0) {
+          loadErrorAction.push(definition[i].name)
+        }
+      }
+
+      if (loadErrorAction.length > 0) {
+        this.$notification.open({
+          message: "Action tree load error",
+          description: loadErrorAction.join(",") + " pack load error",
+          duration: 0,
+          icon: <a-icon type="warning" style="color: red" />,
+          key: this.actionLoadNotifyKey
+        })
+      }
     },
     onOpenChange (openKeys) {
       const latestOpenKey = openKeys.find(key => this.openKeys.indexOf(key) === -1)

--- a/helpdesk/models/provider/__init__.py
+++ b/helpdesk/models/provider/__init__.py
@@ -1,8 +1,9 @@
 # coding: utf-8
 
+import traceback
+
 from helpdesk.libs.decorators import timed_cache
-
-
+from helpdesk.models.provider.errors import InitProviderError, ResolvePackageError
 from .st2 import ST2Provider
 from .airflow import AirflowProvider
 from .spincycle import SpinCycleProvider
@@ -16,4 +17,7 @@ _providers = {
 
 @timed_cache(minutes=15)
 def get_provider(provider, **kw):
-    return _providers[provider](**kw)
+    try:
+        return _providers[provider](**kw)
+    except Exception as e:
+        raise InitProviderError(error=e, tb=traceback.format_exc(), description=f"Init provider error: {str(e)}")

--- a/helpdesk/models/provider/errors.py
+++ b/helpdesk/models/provider/errors.py
@@ -1,0 +1,24 @@
+class ProviderError(Exception):
+    def __init__(self, error, tb="", description="provider error"):
+        self.description = description
+        self.error = error
+        self.tb = tb
+
+    def __str__(self):
+        return '[{message}] {description}'.format(**self.to_dict())
+
+    __repr__ = __str__
+
+    def to_dict(self):
+        return {
+            'description': self.description,
+            'message': str(self.error)
+        }
+
+
+class ResolvePackageError(ProviderError):
+    pass
+
+
+class InitProviderError(ProviderError):
+    pass

--- a/helpdesk/models/provider/st2.py
+++ b/helpdesk/models/provider/st2.py
@@ -2,6 +2,7 @@
 
 import logging
 import requests
+import traceback
 
 from helpdesk.config import (
     ST2_DEFAULT_PACK,
@@ -14,6 +15,7 @@ from helpdesk.config import (
 )
 from helpdesk.libs.sentry import report
 from helpdesk.libs.st2 import get_client, get_api_client, Execution, Token
+from helpdesk.models.provider.errors import ResolvePackageError
 
 from .base import BaseProvider
 
@@ -61,7 +63,10 @@ class ST2Provider(BaseProvider):
         to dict
         '''
         if pack:
-            actions = self.st2.actions.query(pack=pack)
+            try:
+                actions = self.st2.actions.query(pack=pack)
+            except Exception as e:
+                raise ResolvePackageError(e, traceback.format_exc(), f"Resolve pack {pack} error")
         else:
             actions = self.st2.actions.get_all()
         return [action.to_dict() for action in actions]


### PR DESCRIPTION
When some provider died, just notify user with notification instead of refuse to serve all provider's services.  We can still use healthy provider's action and ticket list (except we can not get log from crashed provider).

![image](https://user-images.githubusercontent.com/3339663/102479219-93df7000-4099-11eb-91bd-86b1c1eb6666.png)
