### PR TITLE
fix action button show

### DIFF
--- a/frontend/pages/ticket/_id/index.vue
+++ b/frontend/pages/ticket/_id/index.vue
@@ -238,7 +238,7 @@ export default {
       }
     },
     showActionButtons () {
-      if (this.ticketInfo.status === 'pending' && this.$store.getters.isAdmin) {
+      if (this.ticketInfo.status === 'pending' && (this.$store.getters.isAdmin || this.ticketAnnotation.approvers.includes(this.$store.state.userProfile.name))) {
         return true
       }
       return false


### PR DESCRIPTION
后端的检查是正常的，前端复现详情没有出现按钮
之前可能是漏了改？☹
直接从喵帕斯中选择approve跳转应该会直接通过，详情中加上校验应该就好了

审批人列表中只有自己的单子，没有负责审批的单子 （列表展示负责审批的单子需要过滤审批人，之前未加上，所以是符合现状，后续可以看着加一下）