### PR TITLE
add app approvers check before create ticket

### DIFF
--- a/helpdesk/models/action.py
+++ b/helpdesk/models/action.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from helpdesk.libs.rest import DictSerializableClassMixin
 from helpdesk.models.db.ticket import Ticket, TicketPhase
 from helpdesk.config import AUTO_APPROVAL_TARGET_OBJECTS, PARAM_FILLUP, TICKET_CALLBACK_PARAMS
+from helpdesk.views.api.schemas import ApproverType
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +103,10 @@ class Action(DictSerializableClassMixin):
         ticket.annotate(policy=policy.name)
         ticket.annotate(current_node=policy.init_node.get("name"))
         ticket.annotate(approval_log=list())
-        ticket.annotate(approvers=await ticket.get_node_approvers(policy.init_node.get("name")))
+        approvers = await ticket.get_node_approvers(policy.init_node.get("name"))
+        if not approvers and policy.init_node.get("approver_type") == ApproverType.APP_OWNER:
+            return None, "Failed to get app approvers, please confirm that the app name is entered correctly"
+        ticket.annotate(approvers=approvers)
         
         ret, msg = await ticket.pre_approve()
         if not ret:


### PR DESCRIPTION
观察了下，大部分审批阻塞的都是填入的app和实际app name不一致，光校验app字段意义不大

在获取获取节点审批人时，APP Owner为空的时候有两种场景：
1. 填入的 app 不一致，从而获取不到审批人
2. app 正确，但确实没有应用的owner作为审批人

因此 app owner 类型审批节点的审批人不能为空，为空时不能创建ticket，后续包含app owner的审批流均优先把owenr审批作为初始审批节点