### PR TITLE
Show all workflow nodes by default

### DIFF
--- a/helpdesk/models/provider/airflow.py
+++ b/helpdesk/models/provider/airflow.py
@@ -51,7 +51,7 @@ class AirflowProvider(BaseProvider):
         else:
             self.airflow_client = AirflowClient(username=AIRFLOW_USERNAME, passwd=AIRFLOW_PASSWORD)
         self.default_tag = AIRFLOW_DEFAULT_DAG_TAG
-        self.default_status_filter = ('skipped',)
+        self.default_status_filter = ()
 
     def get_default_pack(self):
         return self.default_tag


### PR DESCRIPTION
Do not show `skipped` workflow node in airflow cause flow chart broken (some node has no edge to them). This is a design before async_ssh_operator exists. Just show all nodes by default. If user needs hide some unused nodes, use `status_filter` in dag schema.