### PR TITLE
Change node transation use annotation record

### DIFF
--- a/helpdesk/models/action.py
+++ b/helpdesk/models/action.py
@@ -109,10 +109,11 @@ class Action(DictSerializableClassMixin):
 
         ticket.annotate(nodes=policy.definition.get("nodes") or [])
         ticket.annotate(policy=policy.name)
-        ticket.annotate(current_node=policy.init_node.get("name"))
         ticket.annotate(approval_log=list())
-        approvers = await ticket.get_node_approvers(policy.init_node.get("name"))
-        if not approvers and policy.init_node.get("approver_type") == ApproverType.APP_OWNER:
+        current_node = ticket.init_node
+        ticket.annotate(current_node=current_node.get("name"))
+        approvers = await ticket.get_node_approvers(current_node.get("name"))
+        if not approvers and current_node.get("approver_type") == ApproverType.APP_OWNER:
             return None, "Failed to get app approvers, please confirm that the app name is entered correctly"
         ticket.annotate(approvers=approvers)
         

--- a/helpdesk/models/db/policy.py
+++ b/helpdesk/models/db/policy.py
@@ -22,35 +22,6 @@ class Policy(db.Model):
     updated_by = db.Column(db.String(length=32))
     updated_at = db.Column(db.DateTime)
 
-    @property
-    def init_node(self):
-        nodes = self.definition.get("nodes")
-        if not nodes or len(nodes) == 0:
-            return None
-        return nodes[0]
-
-    def next_node(self, node_name):
-        nodes = self.definition.get("nodes")
-        for index, node in enumerate(nodes):
-            if node.get("name") == node_name:
-                return nodes[index+1] if (index != len(nodes)-1) else None
-        
-
-    def is_end_node(self, node_name):
-        nodes = self.definition.get("nodes")
-        for index, node in enumerate(nodes):
-            if node.get("name") == node_name:
-                return index == len(nodes)-1
-
-    def is_auto_approved(self):
-        return len(self.definition.get("nodes")) == 1 and self.init_node.get("node_type")  == NodeType.CC.value
-
-    def is_cc_node(self, node_name):
-        for node in self.definition.get("nodes"):
-            if node.get("name") == node_name and node.get("node_type") == NodeType.CC.value:
-                return True
-        return False
-
 
 class TicketPolicy(db.Model):
     __tablename__ = 'ticket_policy'

--- a/helpdesk/tests/test_flow.py
+++ b/helpdesk/tests/test_flow.py
@@ -49,8 +49,10 @@ async def test_flow_match(test_action, test_admin_user, params, policy_name, app
     policy = await ticket.get_flow_policy()
     assert policy.name == policy_name
     # 测试节点 approver 获取
-    ticket.annotate(nodes=policy.definition.get("nodes") or [], policy=policy.name, current_node=policy.init_node.get("name"), approval_log=list())
-    node_approvers = await ticket.get_node_approvers(policy.init_node.get("name"))
+    ticket.annotate(nodes=policy.definition.get("nodes") or [], policy=policy.name, approval_log=list())
+    current_node = ticket.init_node.get("name")
+    ticket.annotate(current_node=current_node)
+    node_approvers = await ticket.get_node_approvers(current_node)
     assert node_approvers == approvers
     # 测试能看到 ticket 的用户
     assert await ticket.can_view(test_user) == can_view
@@ -78,8 +80,10 @@ async def test_mail_notify(test_action, test_admin_user, test_all_policy, phase,
         reason=params.get("reason"),
         created_at=datetime.now())
     policy = await ticket.get_flow_policy()
-    ticket.annotate(nodes=policy.definition.get("nodes") or [], policy=policy.name, current_node=policy.init_node.get("name"), approval_log=list())
-    approvers = await ticket.get_node_approvers(policy.init_node.get("name"))
+    ticket.annotate(nodes=policy.definition.get("nodes") or [], policy=policy.name, approval_log=list())
+    current_node = ticket.init_node.get("name")
+    ticket.annotate(current_node=current_node)
+    approvers = await ticket.get_node_approvers(current_node)
     ticket.annotate(approvers=approvers)
     mail_notify = MailNotification(phase, ticket)
     mail_addrs = await mail_notify.get_mail_addrs()
@@ -108,7 +112,9 @@ async def test_node_transfer(test_action, test_admin_user, test_combined_policy)
         created_at=datetime.now())
     policy = await ticket.get_flow_policy()
 
-    ticket.annotate(nodes=policy.definition.get("nodes") or [], policy=policy.name, current_node=policy.init_node.get("name"), approval_log=list())
+    ticket.annotate(nodes=policy.definition.get("nodes") or [], policy=policy.name, approval_log=list())
+    current_node = ticket.init_node.get("name")
+    ticket.annotate(current_node=current_node)
     ret, msg = await ticket.approve()
     assert ret == True
     assert msg == 'Success'


### PR DESCRIPTION
bug: 修改工单关联的审批流，若还存在相关工单未审批完成的，则再审批可能会出错 (因为审批流程中会去再获取关联policy后处理，因此会拿到新配置的policy，从而导致节点流转异常)
调整为：
审批流执行均从工单 annotation 中获取节点信息，若出现更改，已存在工单按照原有方式审批，新提交工单会按照新配置的