### PR TITLE
When updating form, if field value is empty, delete the field.

### DIFF
--- a/frontend/components/DynamicForm.vue
+++ b/frontend/components/DynamicForm.vue
@@ -25,7 +25,11 @@ export default {
   },
   methods: {
     updateForm (fieldName, v) {
-      this.$set(this.formData, fieldName, v)
+      if (!v) {
+        this.$delete(this.formData, fieldName)
+      } else {
+        this.$set(this.formData, fieldName, v)
+      }
       this.$emit('input', this.formData)
     },
     getComponent(field) {


### PR DESCRIPTION
When user filled a form then deleted a optional field, previously the field would be an empty string, which could be probelmatic.

This change can delete empty field, get rid of the problem.