### PR TITLE
Use real task status

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
     - name: Cache node_modules 📦
-      uses: actions/cache@v2.1.4
+      uses: actions/cache@v3
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         check-latest: true
 
     - name: Cache node_modules 📦
-      uses: actions/cache@v2.1.4
+      uses: actions/cache@v3
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/frontend/components/ResultHostTable.vue
+++ b/frontend/components/ResultHostTable.vue
@@ -54,7 +54,8 @@
       </template>
       <template slot="status" slot-scope="text">
         <span v-if="text==='Success'"><a-tag color="green">Success</a-tag></span>
-        <span v-else><a-tag color="red">Failed</a-tag></span>
+        <span v-else-if="text==='Failed'"><a-tag color="red">Failed</a-tag></span>
+        <span v-else><a-tag color="blue">{{ text }}</a-tag></span>
       </template>
     </a-table>
   </div>
@@ -146,17 +147,14 @@ export default {
         count += 1
         el.id = count
         el.name = property
-        if (el.succeeded || !el.failed) {
+        if (el.succeeded) {
           successCount += 1
           el.status = 'Success'
-        } else if (el.failed || !el.succeeded) {
-          failedCount += 1
-          el.status = 'Failed'
-        } else {
-          // Unknown count as failed
+        } else if (el.failed) {
           failedCount += 1
           el.status = 'Failed'
         }
+        el.status = el.status ? el.status : "-"
         listData.push(el)
 
         if (el.highlight_queries) {

--- a/helpdesk/tests/conftest.py
+++ b/helpdesk/tests/conftest.py
@@ -76,7 +76,7 @@ def anyio_backend():
 @pytest.fixture(scope="session")
 async def test_client():
     from helpdesk import app, config
-    async with AsyncClient(app=app, base_url="http://test", headers={"host": config.TRUSTED_HOSTS[0]}) as test_client:
+    async with AsyncClient(base_url="http://test", headers={"host": config.TRUSTED_HOSTS[0]}) as test_client:
         print("Client is ready")
         yield test_client
 

--- a/helpdesk/tests/conftest.py
+++ b/helpdesk/tests/conftest.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 from pytest import MonkeyPatch
 from helpdesk import config
 from helpdesk.libs.auth import Validator
@@ -76,7 +76,8 @@ def anyio_backend():
 @pytest.fixture(scope="session")
 async def test_client():
     from helpdesk import app, config
-    async with AsyncClient(base_url="http://test", headers={"host": config.TRUSTED_HOSTS[0]}) as test_client:
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test", headers={"host": config.TRUSTED_HOSTS[0]}) as test_client:
         print("Client is ready")
         yield test_client
 


### PR DESCRIPTION
- show task running/no_status(-) etc status in task table

user often feels confused with the default task failed status (even when task is not scheduled to run)